### PR TITLE
Shorter tracebacks for run failures

### DIFF
--- a/nbsmoke/__init__.py
+++ b/nbsmoke/__init__.py
@@ -257,6 +257,10 @@ class VerifyNb(pytest.Item):
 
 
 class RunNb(pytest.Item):
+
+    def repr_failure(self, excinfo):
+        return excinfo.exconly(True)
+
     def runtest(self):
         self._skip()
         with io.open(self.name,encoding='utf8') as nb:


### PR DESCRIPTION
Addresses #4 

Before:

```
(nbsdev) D:\code\pyviz\nbsmoke2>pytest --nbsmoke-run test-notebooks
=============================================================== test session starts ================================================================
platform win32 -- Python 3.6.8, pytest-4.3.0, py-1.8.0, pluggy-0.9.0
rootdir: D:\code\pyviz\nbsmoke2, inifile:
plugins: nbsmoke-0.2.7.post1+g08e6932.dirty
collected 3 items

test-notebooks\Untitled.ipynb .                                                                                                               [ 33%]
test-notebooks\Untitled2.ipynb .                                                                                                              [ 66%]
test-notebooks\Untitled3.ipynb F                                                                                                              [100%]

===================================================================== FAILURES =====================================================================
_________________________________________________________________________  _________________________________________________________________________

cls = <class '_pytest.runner.CallInfo'>, func = <function call_runtest_hook.<locals>.<lambda> at 0x00747660>, when = 'call'
reraise = (<class '_pytest.outcomes.Exit'>, <class 'KeyboardInterrupt'>)

    @classmethod
    def from_call(cls, func, when, reraise=None):
        #: context of invocation: one of "setup", "call",
        #: "teardown", "memocollect"
        start = time()
        excinfo = None
        try:
>           result = func()

d:\venvs\nbsdev\lib\site-packages\_pytest\runner.py:226:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>       lambda: ihook(item=item, **kwds), when=when, reraise=reraise
    )

d:\venvs\nbsdev\lib\site-packages\_pytest\runner.py:198:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <_HookCaller 'pytest_runtest_call'>, args = (), kwargs = {'item': <RunNb D:\code\pyviz\nbsmoke2\test-notebooks\Untitled3.ipynb>}
notincall = set()

    def __call__(self, *args, **kwargs):
        if args:
            raise TypeError("hook calling supports only keyword arguments")
        assert not self.is_historic()
        if self.spec and self.spec.argnames:
            notincall = (
                set(self.spec.argnames) - set(["__multicall__"]) - set(kwargs.keys())
            )
            if notincall:
                warnings.warn(
                    "Argument(s) {} which are declared in the hookspec "
                    "can not be found in this hook call".format(tuple(notincall)),
                    stacklevel=2,
                )
>       return self._hookexec(self, self.get_hookimpls(), kwargs)

d:\venvs\nbsdev\lib\site-packages\pluggy\hooks.py:289:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <_pytest.config.PytestPluginManager object at 0x0211D9F0>, hook = <_HookCaller 'pytest_runtest_call'>
methods = [<HookImpl plugin_name='runner', plugin=<module '_pytest.runner' from 'd:\\venvs\\nbsdev\\lib\\site-packages\\_pytest\... at 0x02B859F0>>, <HookImpl plugin_name='logging-plugin', plugin=<_pytest.logging.LoggingPlugin object at 0x03BB3F50>>]
kwargs = {'item': <RunNb D:\code\pyviz\nbsmoke2\test-notebooks\Untitled3.ipynb>}

    def _hookexec(self, hook, methods, kwargs):
        # called from all hookcaller instances.
        # enable_tracing will set its own wrapping function at self._inner_hookexec
>       return self._inner_hookexec(hook, methods, kwargs)

d:\venvs\nbsdev\lib\site-packages\pluggy\manager.py:68:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

hook = <_HookCaller 'pytest_runtest_call'>
methods = [<HookImpl plugin_name='runner', plugin=<module '_pytest.runner' from 'd:\\venvs\\nbsdev\\lib\\site-packages\\_pytest\... at 0x02B859F0>>, <HookImpl plugin_name='logging-plugin', plugin=<_pytest.logging.LoggingPlugin object at 0x03BB3F50>>]
kwargs = {'item': <RunNb D:\code\pyviz\nbsmoke2\test-notebooks\Untitled3.ipynb>}

    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
        methods,
        kwargs,
>       firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
    )

d:\venvs\nbsdev\lib\site-packages\pluggy\manager.py:62:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

hook_impls = [<HookImpl plugin_name='runner', plugin=<module '_pytest.runner' from 'd:\\venvs\\nbsdev\\lib\\site-packages\\_pytest\... at 0x02B859F0>>, <HookImpl plugin_name='logging-plugin', plugin=<_pytest.logging.LoggingPlugin object at 0x03BB3F50>>]
caller_kwargs = {'item': <RunNb D:\code\pyviz\nbsmoke2\test-notebooks\Untitled3.ipynb>}, firstresult = False

    def _multicall(hook_impls, caller_kwargs, firstresult=False):
        """Execute a call into multiple python functions/methods and return the
        result(s).

        ``caller_kwargs`` comes from _HookCaller.__call__().
        """
        __tracebackhide__ = True
        results = []
        excinfo = None
        try:  # run impl and wrapper setup functions in a loop
            teardowns = []
            try:
                for hook_impl in reversed(hook_impls):
                    try:
                        args = [caller_kwargs[argname] for argname in hook_impl.argnames]
                    except KeyError:
                        for argname in hook_impl.argnames:
                            if argname not in caller_kwargs:
                                raise HookCallError(
                                    "hook call must provide argument %r" % (argname,)
                                )

                    if hook_impl.hookwrapper:
                        try:
                            gen = hook_impl.function(*args)
                            next(gen)  # first yield
                            teardowns.append(gen)
                        except StopIteration:
                            _raise_wrapfail(gen, "did not yield")
                    else:
                        res = hook_impl.function(*args)
                        if res is not None:
                            results.append(res)
                            if firstresult:  # halt further impl calls
                                break
            except BaseException:
                excinfo = sys.exc_info()
        finally:
            if firstresult:  # first result hooks return a single value
                outcome = _Result(results[0] if results else None, excinfo)
            else:
                outcome = _Result(results, excinfo)

            # run all wrapper post-yield blocks
            for gen in reversed(teardowns):
                try:
                    gen.send(outcome)
                    _raise_wrapfail(gen, "has second yield")
                except StopIteration:
                    pass

>           return outcome.get_result()

d:\venvs\nbsdev\lib\site-packages\pluggy\callers.py:208:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pluggy.callers._Result object at 0x04BC7FB0>

    def get_result(self):
        """Get the result(s) for this hook call.

        If the hook was marked as a ``firstresult`` only a single value
        will be returned otherwise a list of results.
        """
        __tracebackhide__ = True
        if self._excinfo is None:
            return self._result
        else:
            ex = self._excinfo
            if _py3:
>               raise ex[1].with_traceback(ex[2])

d:\venvs\nbsdev\lib\site-packages\pluggy\callers.py:80:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

hook_impls = [<HookImpl plugin_name='runner', plugin=<module '_pytest.runner' from 'd:\\venvs\\nbsdev\\lib\\site-packages\\_pytest\... at 0x02B859F0>>, <HookImpl plugin_name='logging-plugin', plugin=<_pytest.logging.LoggingPlugin object at 0x03BB3F50>>]
caller_kwargs = {'item': <RunNb D:\code\pyviz\nbsmoke2\test-notebooks\Untitled3.ipynb>}, firstresult = False

    def _multicall(hook_impls, caller_kwargs, firstresult=False):
        """Execute a call into multiple python functions/methods and return the
        result(s).

        ``caller_kwargs`` comes from _HookCaller.__call__().
        """
        __tracebackhide__ = True
        results = []
        excinfo = None
        try:  # run impl and wrapper setup functions in a loop
            teardowns = []
            try:
                for hook_impl in reversed(hook_impls):
                    try:
                        args = [caller_kwargs[argname] for argname in hook_impl.argnames]
                    except KeyError:
                        for argname in hook_impl.argnames:
                            if argname not in caller_kwargs:
                                raise HookCallError(
                                    "hook call must provide argument %r" % (argname,)
                                )

                    if hook_impl.hookwrapper:
                        try:
                            gen = hook_impl.function(*args)
                            next(gen)  # first yield
                            teardowns.append(gen)
                        except StopIteration:
                            _raise_wrapfail(gen, "did not yield")
                    else:
>                       res = hook_impl.function(*args)

d:\venvs\nbsdev\lib\site-packages\pluggy\callers.py:187:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

item = <RunNb D:\code\pyviz\nbsmoke2\test-notebooks\Untitled3.ipynb>

    def pytest_runtest_call(item):
        _update_current_test_var(item, "call")
        sys.last_type, sys.last_value, sys.last_traceback = (None, None, None)
        try:
>           item.runtest()

d:\venvs\nbsdev\lib\site-packages\_pytest\runner.py:123:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <RunNb D:\code\pyviz\nbsmoke2\test-notebooks\Untitled3.ipynb>

    def runtest(self):
        self._skip()
        with io.open(self.name,encoding='utf8') as nb:
            notebook = nbformat.read(nb, as_version=4)

            # TODO: which kernel? run in pytest's or use new one (make it option)
            _timeout = self.parent.parent.config.getini('nbsmoke_cell_timeout')
            kwargs = dict(timeout=int(_timeout) if _timeout!='' else 300,
                          allow_errors=False,
                          # or sys.version_info[1] ?
                          kernel_name='python')

            ep = ExecutePreprocessor(**kwargs)
            with cwd(os.path.dirname(self.name)): # jupyter notebook always does this, right?
>               ep.preprocess(notebook,{})

nbsmoke\__init__.py:278:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <nbconvert.preprocessors.execute.ExecutePreprocessor object at 0x04BD9890>
nb = {'cells': [{'cell_type': 'code', 'execution_count': 1, 'metadata': {}, 'outputs': [{'output_type': 'stream', 'name': '...], 'metadata': {'language_info': {'name': 'python', 'pygments_lexer': 'ipython3'}}, 'nbformat': 4, 'nbformat_minor': 2}
resources = {}, km = None

    def preprocess(self, nb, resources, km=None):
        """
        Preprocess notebook executing each code cell.

        The input argument `nb` is modified in-place.

        Parameters
        ----------
        nb : NotebookNode
            Notebook being executed.
        resources : dictionary
            Additional resources used in the conversion process. For example,
            passing ``{'metadata': {'path': run_path}}`` sets the
            execution path to ``run_path``.
        km: KernelManager (optional)
            Optional kernel manager. If none is provided, a kernel manager will
            be created.

        Returns
        -------
        nb : NotebookNode
            The executed notebook.
        resources : dictionary
            Additional resources used in the conversion process.
        """

        with self.setup_preprocessor(nb, resources, km=km):
            self.log.info("Executing notebook with kernel: %s" % self.kernel_name)
>           nb, resources = super(ExecutePreprocessor, self).preprocess(nb, resources)

d:\venvs\nbsdev\lib\site-packages\nbconvert\preprocessors\execute.py:354:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <nbconvert.preprocessors.execute.ExecutePreprocessor object at 0x04BD9890>
nb = {'cells': [{'cell_type': 'code', 'execution_count': 1, 'metadata': {}, 'outputs': [{'output_type': 'stream', 'name': '...], 'metadata': {'language_info': {'name': 'python', 'pygments_lexer': 'ipython3'}}, 'nbformat': 4, 'nbformat_minor': 2}
resources = {}

    def preprocess(self, nb, resources):
        """
        Preprocessing to apply on each notebook.

        Must return modified nb, resources.

        If you wish to apply your preprocessing to each cell, you might want
        to override preprocess_cell method instead.

        Parameters
        ----------
        nb : NotebookNode
            Notebook being converted
        resources : dictionary
            Additional resources used in the conversion process.  Allows
            preprocessors to pass variables into the Jinja engine.
        """
        for index, cell in enumerate(nb.cells):
>           nb.cells[index], resources = self.preprocess_cell(cell, resources, index)

d:\venvs\nbsdev\lib\site-packages\nbconvert\preprocessors\base.py:69:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <nbconvert.preprocessors.execute.ExecutePreprocessor object at 0x04BD9890>
cell = {'cell_type': 'code', 'execution_count': 3, 'metadata': {}, 'outputs': [{'output_type': 'stream', 'name': 'stderr', 't...ageError: Cell magic `%%RGB` not found.\n'}], 'source': '%%RGB [width=400]\ndef f2(): return 1\n\n%time z2 = f2()\nz2'}
resources = {}, cell_index = 2

    def preprocess_cell(self, cell, resources, cell_index):
        """
        Executes a single code cell. See base.py for details.

        To execute all cells see :meth:`preprocess`.
        """
        if cell.cell_type != 'code' or not cell.source.strip():
            return cell, resources

        reply, outputs = self.run_cell(cell, cell_index)
        cell.outputs = outputs

        cell_allows_errors = (self.allow_errors or "raises-exception"
                              in cell.metadata.get("tags", []))

        if self.force_raise_errors or not cell_allows_errors:
            for out in outputs:
                if out.output_type == 'error':
                    raise CellExecutionError.from_cell_and_msg(cell, out)
            if (reply is not None) and reply['content']['status'] == 'error':
>               raise CellExecutionError.from_cell_and_msg(cell, reply['content'])
E               nbconvert.preprocessors.execute.CellExecutionError: An error occurred while executing the following cell:
E               ------------------
E               %%RGB [width=400]
E               def f2(): return 1
E
E               %time z2 = f2()
E               z2
E               ------------------
E
E
E               UsageError: Cell magic `%%RGB` not found.

d:\venvs\nbsdev\lib\site-packages\nbconvert\preprocessors\execute.py:380: CellExecutionError
================================================================= warnings summary =================================================================
test-notebooks/Untitled.ipynb::D:\code\pyviz\nbsmoke2\test-notebooks\Untitled.ipynb
  d:\venvs\nbsdev\lib\site-packages\jupyter_client\manager.py:72: DeprecationWarning: KernelManager._kernel_name_changed is deprecated in traitlets 4.1: use @observe and @unobserve instead.
    def _kernel_name_changed(self, name, old, new):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================= 1 failed, 2 passed, 1 warnings in 22.71 seconds ==================================================
```

After:

```
(nbsdev) D:\code\pyviz\nbsmoke2>pytest --nbsmoke-run test-notebooks
=============================================================== test session starts ================================================================
platform win32 -- Python 3.6.8, pytest-4.3.0, py-1.8.0, pluggy-0.9.0
rootdir: D:\code\pyviz\nbsmoke2, inifile:
plugins: nbsmoke-0.2.7.post1+g08e6932.dirty
collected 3 items

test-notebooks\Untitled.ipynb .                                                                                                               [ 33%]
test-notebooks\Untitled2.ipynb .                                                                                                              [ 66%]
test-notebooks\Untitled3.ipynb F                                                                                                              [100%]

===================================================================== FAILURES =====================================================================
_________________________________________________________________________  _________________________________________________________________________
nbconvert.preprocessors.execute.CellExecutionError: An error occurred while executing the following cell:
------------------
%%RGB [width=400]
def f2(): return 1

%time z2 = f2()
z2
------------------


UsageError: Cell magic `%%RGB` not found.
================================================================= warnings summary =================================================================
test-notebooks/Untitled.ipynb::D:\code\pyviz\nbsmoke2\test-notebooks\Untitled.ipynb
  d:\venvs\nbsdev\lib\site-packages\jupyter_client\manager.py:72: DeprecationWarning: KernelManager._kernel_name_changed is deprecated in traitlets 4.1: use @observe and @unobserve instead.
    def _kernel_name_changed(self, name, old, new):

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================= 1 failed, 2 passed, 1 warnings in 31.63 seconds ==================================================
```