### PR TITLE
Shorter lint tracebacks, lint failures as warnings, and lint debugging.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,9 +105,11 @@ hinder understanding of a notebook by readers, or add dependencies
 that are not required.
 
 Using ``# noqa: explanation`` in a notebook might seem like overkill,
-but the intention is to encourage unavoidable/desirable 'mysterious
-imports' to be clarified. E.g. if you're importing something for its
-side effects, it's very helpful to inform the reader of that.
+but the intention is to at least force 'mysterious imports' to be
+clarified (if they are necessary at all, which ideally they shouldn't
+be). E.g. if you're importing something for its side effects, it's
+very helpful to inform the reader of that, and the ugly/strange ``#
+noqa`` should help remind you to fix the underlying problem...
 
 Pyflakes is used as the underlying linter because "Pyflakes makes a
 simple promise: it will never complain about style, and it will try


### PR DESCRIPTION
1. Shorter traceback for lint (addresses #4).

2. `--nbsmoke-lint-onlywarn`: Report lint failures as warnings (#7).

3. `--nbsmoke-lint-debug`: Allow easier investigation (and debugging) of lint failures. nbsmoke lint currently uses nbconvert to convert ipynb to py, then runs pyflakes on that. You can now see the py source that was actually flake checked (pyflakes-reported line numbers correspond to this source). (Note: unhandled magics e.g. from holoviews can cause spurious flakes. I have separate changes that attempt to improve the situation. Meanwhile, this option is also helpful for debugging that situation.)

Demo of the changes using the following example notebook:

```
(nbsdev) D:\code\pyviz\nbsmoke2>type test-notebooks\Untitled5.ipynb
{
 "cells": [
  {
   "cell_type": "code",
   "execution_count": null,
   "metadata": {},
   "outputs": [],
   "source": [
    "import thing\n",
    "z"
   ]
  }
 ],
 "metadata": {
  "language_info": {
   "name": "python",
   "pygments_lexer": "ipython3"
  }
 },
 "nbformat": 4,
 "nbformat_minor": 2
}
```

## shorter lint tracebacks

Current nbsmoke:

```
(nbsdev) D:\code\pyviz\nbsmoke2>pytest --nbsmoke-lint test-notebooks\Untitled5.ipynb
=============================================================== test session starts ================================================================
platform win32 -- Python 3.6.8, pytest-4.3.0, py-1.8.0, pluggy-0.9.0
rootdir: D:\code\pyviz\nbsmoke2, inifile:
plugins: nbsmoke-0.2.7.post1+g08e6932.dirty
collected 1 item

test-notebooks\Untitled5.ipynb F                                                                                                              [100%]

===================================================================== FAILURES =====================================================================
_________________________________________________________________________  _________________________________________________________________________

cls = <class '_pytest.runner.CallInfo'>, func = <function call_runtest_hook.<locals>.<lambda> at 0x048388E8>, when = 'call'
reraise = (<class '_pytest.outcomes.Exit'>, <class 'KeyboardInterrupt'>)

    @classmethod
    def from_call(cls, func, when, reraise=None):
        #: context of invocation: one of "setup", "call",
        #: "teardown", "memocollect"
        start = time()
        excinfo = None
        try:
>           result = func()

d:\venvs\nbsdev\lib\site-packages\_pytest\runner.py:226:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>       lambda: ihook(item=item, **kwds), when=when, reraise=reraise
    )

d:\venvs\nbsdev\lib\site-packages\_pytest\runner.py:198:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <_HookCaller 'pytest_runtest_call'>, args = (), kwargs = {'item': <LintNb D:\code\pyviz\nbsmoke2\test-notebooks\Untitled5.ipynb>}
notincall = set()

    def __call__(self, *args, **kwargs):
        if args:
            raise TypeError("hook calling supports only keyword arguments")
        assert not self.is_historic()
        if self.spec and self.spec.argnames:
            notincall = (
                set(self.spec.argnames) - set(["__multicall__"]) - set(kwargs.keys())
            )
            if notincall:
                warnings.warn(
                    "Argument(s) {} which are declared in the hookspec "
                    "can not be found in this hook call".format(tuple(notincall)),
                    stacklevel=2,
                )
>       return self._hookexec(self, self.get_hookimpls(), kwargs)

d:\venvs\nbsdev\lib\site-packages\pluggy\hooks.py:289:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <_pytest.config.PytestPluginManager object at 0x02D9DA30>, hook = <_HookCaller 'pytest_runtest_call'>
methods = [<HookImpl plugin_name='runner', plugin=<module '_pytest.runner' from 'd:\\venvs\\nbsdev\\lib\\site-packages\\_pytest\... at 0x038DDC50>>, <HookImpl plugin_name='logging-plugin', plugin=<_pytest.logging.LoggingPlugin object at 0x04846A30>>]
kwargs = {'item': <LintNb D:\code\pyviz\nbsmoke2\test-notebooks\Untitled5.ipynb>}

    def _hookexec(self, hook, methods, kwargs):
        # called from all hookcaller instances.
        # enable_tracing will set its own wrapping function at self._inner_hookexec
>       return self._inner_hookexec(hook, methods, kwargs)

d:\venvs\nbsdev\lib\site-packages\pluggy\manager.py:68:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

hook = <_HookCaller 'pytest_runtest_call'>
methods = [<HookImpl plugin_name='runner', plugin=<module '_pytest.runner' from 'd:\\venvs\\nbsdev\\lib\\site-packages\\_pytest\... at 0x038DDC50>>, <HookImpl plugin_name='logging-plugin', plugin=<_pytest.logging.LoggingPlugin object at 0x04846A30>>]
kwargs = {'item': <LintNb D:\code\pyviz\nbsmoke2\test-notebooks\Untitled5.ipynb>}

    self._inner_hookexec = lambda hook, methods, kwargs: hook.multicall(
        methods,
        kwargs,
>       firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
    )

d:\venvs\nbsdev\lib\site-packages\pluggy\manager.py:62:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

hook_impls = [<HookImpl plugin_name='runner', plugin=<module '_pytest.runner' from 'd:\\venvs\\nbsdev\\lib\\site-packages\\_pytest\... at 0x038DDC50>>, <HookImpl plugin_name='logging-plugin', plugin=<_pytest.logging.LoggingPlugin object at 0x04846A30>>]
caller_kwargs = {'item': <LintNb D:\code\pyviz\nbsmoke2\test-notebooks\Untitled5.ipynb>}, firstresult = False

    def _multicall(hook_impls, caller_kwargs, firstresult=False):
        """Execute a call into multiple python functions/methods and return the
        result(s).

        ``caller_kwargs`` comes from _HookCaller.__call__().
        """
        __tracebackhide__ = True
        results = []
        excinfo = None
        try:  # run impl and wrapper setup functions in a loop
            teardowns = []
            try:
                for hook_impl in reversed(hook_impls):
                    try:
                        args = [caller_kwargs[argname] for argname in hook_impl.argnames]
                    except KeyError:
                        for argname in hook_impl.argnames:
                            if argname not in caller_kwargs:
                                raise HookCallError(
                                    "hook call must provide argument %r" % (argname,)
                                )

                    if hook_impl.hookwrapper:
                        try:
                            gen = hook_impl.function(*args)
                            next(gen)  # first yield
                            teardowns.append(gen)
                        except StopIteration:
                            _raise_wrapfail(gen, "did not yield")
                    else:
                        res = hook_impl.function(*args)
                        if res is not None:
                            results.append(res)
                            if firstresult:  # halt further impl calls
                                break
            except BaseException:
                excinfo = sys.exc_info()
        finally:
            if firstresult:  # first result hooks return a single value
                outcome = _Result(results[0] if results else None, excinfo)
            else:
                outcome = _Result(results, excinfo)

            # run all wrapper post-yield blocks
            for gen in reversed(teardowns):
                try:
                    gen.send(outcome)
                    _raise_wrapfail(gen, "has second yield")
                except StopIteration:
                    pass

>           return outcome.get_result()

d:\venvs\nbsdev\lib\site-packages\pluggy\callers.py:208:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pluggy.callers._Result object at 0x0486BA50>

    def get_result(self):
        """Get the result(s) for this hook call.

        If the hook was marked as a ``firstresult`` only a single value
        will be returned otherwise a list of results.
        """
        __tracebackhide__ = True
        if self._excinfo is None:
            return self._result
        else:
            ex = self._excinfo
            if _py3:
>               raise ex[1].with_traceback(ex[2])

d:\venvs\nbsdev\lib\site-packages\pluggy\callers.py:80:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

hook_impls = [<HookImpl plugin_name='runner', plugin=<module '_pytest.runner' from 'd:\\venvs\\nbsdev\\lib\\site-packages\\_pytest\... at 0x038DDC50>>, <HookImpl plugin_name='logging-plugin', plugin=<_pytest.logging.LoggingPlugin object at 0x04846A30>>]
caller_kwargs = {'item': <LintNb D:\code\pyviz\nbsmoke2\test-notebooks\Untitled5.ipynb>}, firstresult = False

    def _multicall(hook_impls, caller_kwargs, firstresult=False):
        """Execute a call into multiple python functions/methods and return the
        result(s).

        ``caller_kwargs`` comes from _HookCaller.__call__().
        """
        __tracebackhide__ = True
        results = []
        excinfo = None
        try:  # run impl and wrapper setup functions in a loop
            teardowns = []
            try:
                for hook_impl in reversed(hook_impls):
                    try:
                        args = [caller_kwargs[argname] for argname in hook_impl.argnames]
                    except KeyError:
                        for argname in hook_impl.argnames:
                            if argname not in caller_kwargs:
                                raise HookCallError(
                                    "hook call must provide argument %r" % (argname,)
                                )

                    if hook_impl.hookwrapper:
                        try:
                            gen = hook_impl.function(*args)
                            next(gen)  # first yield
                            teardowns.append(gen)
                        except StopIteration:
                            _raise_wrapfail(gen, "did not yield")
                    else:
>                       res = hook_impl.function(*args)

d:\venvs\nbsdev\lib\site-packages\pluggy\callers.py:187:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

item = <LintNb D:\code\pyviz\nbsmoke2\test-notebooks\Untitled5.ipynb>

    def pytest_runtest_call(item):
        _update_current_test_var(item, "call")
        sys.last_type, sys.last_value, sys.last_traceback = (None, None, None)
        try:
>           item.runtest()

d:\venvs\nbsdev\lib\site-packages\_pytest\runner.py:123:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <LintNb D:\code\pyviz\nbsmoke2\test-notebooks\Untitled5.ipynb>

    def runtest(self):
        with io.open(self.name,encoding='utf8') as nbfile:
            nb = nbformat.read(nbfile, as_version=4)
            _insert_get_ipython(nb)
            py, resources = nbconvert.PythonExporter().from_notebook_node(nb)
            py = insert_ipython_magic_content(py)
            if sys.version_info[0]==2:
                # notebooks will start with "coding: utf-8", but py already unicode
                py = py.encode('utf8')
            if flake_check(py,self.name) != 0:
>               raise AssertionError
E               AssertionError

nbsmoke\__init__.py:391: AssertionError
--------------------------------------------------------------- Captured stdout call ---------------------------------------------------------------
D:\code\pyviz\nbsmoke2\test-notebooks\Untitled5.ipynb:14: 'thing' imported but unused
D:\code\pyviz\nbsmoke2\test-notebooks\Untitled5.ipynb:15: undefined name 'z'
============================================================= 1 failed in 9.06 seconds =============================================================
```

This PR:

```
(nbsdev) D:\code\pyviz\nbsmoke2>pytest --nbsmoke-lint test-notebooks\Untitled5.ipynb
=============================================================== test session starts ================================================================
platform win32 -- Python 3.6.8, pytest-4.3.0, py-1.8.0, pluggy-0.9.0
rootdir: D:\code\pyviz\nbsmoke2, inifile:
plugins: nbsmoke-0.2.7.post1+g08e6932.dirty
collected 1 item

test-notebooks\Untitled5.ipynb F                                                                                                              [100%]

===================================================================== FAILURES =====================================================================
_________________________________________________________________________  _________________________________________________________________________
D:\code\pyviz\nbsmoke2\test-notebooks\Untitled5.ipynb
line 14 col 0: 'thing' imported but unused
line 15 col 0: undefined name 'z'
To see python source that was flake checked: pass --nbsmoke-lint-debug
============================================================= 1 failed in 1.87 seconds =============================================================
```

## lint debugging

nbsmoke is using nbconvert for ipynb to py, and running pyflakes on that. You can see the python source that was actually lint checked:

```
(nbsdev) D:\code\pyviz\nbsmoke2>pytest --nbsmoke-lint --nbsmoke-lint-debug test-notebooks\Untitled5.ipynb
=============================================================== test session starts ================================================================
platform win32 -- Python 3.6.8, pytest-4.3.0, py-1.8.0, pluggy-0.9.0
rootdir: D:\code\pyviz\nbsmoke2, inifile:
plugins: nbsmoke-0.2.7.post1+g08e6932.dirty
collected 1 item

test-notebooks\Untitled5.ipynb F                                                                                                              [100%]

===================================================================== FAILURES =====================================================================
_________________________________________________________________________  _________________________________________________________________________
D:\code\pyviz\nbsmoke2\test-notebooks\Untitled5.ipynb
line 14 col 0: 'thing' imported but unused
line 15 col 0: undefined name 'z'
To see python source that was flake checked: D:\code\pyviz\nbsmoke2\test-notebooks\Untitled5.nbsmoke-debug.py
============================================================= 1 failed in 2.25 seconds =============================================================

(nbsdev) D:\code\pyviz\nbsmoke2>type test-notebooks\Untitled5.nbsmoke-debug.py
#!/usr/bin/env python
# coding: utf-8

# In[ ]:


from IPython import get_ipython
get_ipython()


# In[ ]:


import thing
z
```

## lint as warnings

If you're already running notebooks, and they ran successfully, flakes are likely to be things like unused names. In this case, you might want flakes to just be warnings rather than failures (although I'm not sure how much use warnings are on e.g. travis, since they are not detected/reported; actually, I'm not really sure how useful warnings ever are...):

```
(nbsdev) D:\code\pyviz\nbsmoke2>pytest --nbsmoke-lint --nbsmoke-lint-onlywarn test-notebooks\Untitled5.ipynb
=============================================================== test session starts ================================================================
platform win32 -- Python 3.6.8, pytest-4.3.0, py-1.8.0, pluggy-0.9.0
rootdir: D:\code\pyviz\nbsmoke2, inifile:
plugins: nbsmoke-0.2.7.post1+g08e6932.dirty
collected 1 item

test-notebooks\Untitled5.ipynb .                                                                                                              [100%]

================================================================= warnings summary =================================================================
test-notebooks/Untitled5.ipynb::D:\code\pyviz\nbsmoke2\test-notebooks\Untitled5.ipynb
  d:\code\pyviz\nbsmoke2\nbsmoke\__init__.py:441: UserWarning: Flakes detected:
  D:\code\pyviz\nbsmoke2\test-notebooks\Untitled5.ipynb
  line 14 col 0: 'thing' imported but unused
  line 15 col 0: undefined name 'z'
  To see python source that was flake checked: pass --nbsmoke-lint-debug
    warnings.warn("Flakes detected:\n"+msg)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
======================================================= 1 passed, 1 warnings in 1.87 seconds =======================================================
```
